### PR TITLE
[Feat] Enable SwiftUI Previews for UIKit

### DIFF
--- a/solutions/devsprint-riccardo-1/OnboardingChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4645BF89276347CD0079B5A2 /* SwiftUIPreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4645BF88276347CD0079B5A2 /* SwiftUIPreView.swift */; };
 		980C0C2E2705077B00F8100A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980C0C2D2705077B00F8100A /* AppDelegate.swift */; };
 		980C0C302705077B00F8100A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980C0C2F2705077B00F8100A /* SceneDelegate.swift */; };
 		980C0C322705077B00F8100A /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980C0C312705077B00F8100A /* ListViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4645BF88276347CD0079B5A2 /* SwiftUIPreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIPreView.swift; sourceTree = "<group>"; };
 		980C0C2A2705077B00F8100A /* OnboardingChallenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OnboardingChallenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		980C0C2D2705077B00F8100A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		980C0C2F2705077B00F8100A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -73,6 +75,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4645BF87276347B60079B5A2 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4645BF88276347CD0079B5A2 /* SwiftUIPreView.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		980C0C212705077B00F8100A = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +104,7 @@
 		980C0C2C2705077B00F8100A /* OnboardingChallenge */ = {
 			isa = PBXGroup;
 			children = (
+				4645BF87276347B60079B5A2 /* Helpers */,
 				980C0C4527061F3B00F8100A /* Resources */,
 				980C0C4127061EC000F8100A /* AppDelegate */,
 				980C0C4227061ED300F8100A /* Screens */,
@@ -302,6 +313,7 @@
 				98586A0D270E40DF0088A775 /* UIViewController+Extensions.swift in Sources */,
 				98586A06270E3EC40088A775 /* ListViewConfiguration.swift in Sources */,
 				98586A09270E40430088A775 /* UITableViewCell+Extensions.swift in Sources */,
+				4645BF89276347CD0079B5A2 /* SwiftUIPreView.swift in Sources */,
 				980C0C2E2705077B00F8100A /* AppDelegate.swift in Sources */,
 				980C0C302705077B00F8100A /* SceneDelegate.swift in Sources */,
 				9824AD66273322C6001044D2 /* SettingsViewController.swift in Sources */,

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
@@ -10,6 +10,27 @@ import Foundation
 #if DEBUG
 import SwiftUI
 
+/// Generic structure that implement the boilerplate to make a UIView representable in SwiftUI
+/// This struct is meant to be used in SwiftUI previews, where we are interested in quickly checking
+/// what we are implementing. It shouldn't be used when you need a UIKit component work with the
+/// SwiftUI parts of the production app.
+///
+/// To use it, copy and paste the following snippet in the UIKit View and replace the name of the preview
+/// and the commented code.
+///
+/// ```swift
+/// #if DEBUG
+/// import SwiftUI
+///
+/// struct <#YourView#>_Preview: PreviewProvider {
+///     static var previews: some View {
+///         return SwiftUIPreView { context in
+///             // code to initialize and configure your view
+///         }
+///     }
+/// }
+/// #endif
+/// ```
 struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
     
     let viewFactory: (Context) -> V

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
@@ -1,0 +1,24 @@
+//
+//  SwiftUIPreView.swift
+//  OnboardingChallenge
+//
+//  Created by Riccardo Cipolleschi on 10/12/21.
+//
+
+import Foundation
+import SwiftUI
+
+struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
+    
+    let viewFactory: (Context) -> V
+    
+    func makeUIView(context: Context) -> V {
+        return viewFactory(context)
+    }
+    
+    func updateUIView(_ uiView: V, context: Context) {
+        
+    }
+    
+    
+}

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+
+#if DEBUG
 import SwiftUI
 
 struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
@@ -19,6 +21,5 @@ struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
     func updateUIView(_ uiView: V, context: Context) {
         
     }
-    
-    
 }
+#endif

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
@@ -99,5 +99,4 @@ struct ListView_Preview: PreviewProvider {
         }
     }
 }
-
 #endif

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
@@ -85,3 +85,19 @@ extension ListView: UITableViewDataSource {
     }
 }
 
+#if DEBUG
+import SwiftUI
+
+struct ListView_Preview: PreviewProvider {
+    static var previews: some View {
+        return SwiftUIPreView { context in
+            let lv = ListView()
+            lv.updateView(with: .init(listItems: [
+                "first", "second", "third", "fourth"
+            ]))
+            return lv
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds a generic `SwiftUIPreView` structure that can be used to enable SwiftUI preview when working with UIKit.
The structure is available only in `DEBUG` mode, the typical mode we use when developing, and it is not shipped with the app when it is built in `RELEASE` mode.

The PR show how this can be used in the `ListView`: we just have to define a `PreviewProvider` and we instantiate the  `SwiftUIPreView` struct passing a factory for the list view.

SwiftUI Preview with UIKit could be used even without the `SwiftUIPreView`, but they require that, for each view, we create a `UIViewRepresentable` struct that instantiates the UIKit View. This PR prevent that boilerplate.

