### PR TITLE
[Tools] Configure SwiftLint and SwiftFormat in the project

### DIFF
--- a/bin/install_tooling.sh
+++ b/bin/install_tooling.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+if ! which swiftlint > /dev/null; then
+  echo "installing swiftlint..."
+  brew install swiftlint
+else
+  echo "swift lint installed"
+fi
+
+if ! which swiftformat > /dev/null; then
+  echo "installing swiftformat..."
+  brew install swiftformat
+else
+  echo "swiftformat installed"
+fi

--- a/solutions/devsprint-riccardo-1/.swiftformat
+++ b/solutions/devsprint-riccardo-1/.swiftformat
@@ -1,0 +1,272 @@
+# Please, read the following conventions before to edit this file:
+# - Rules are sorted alphabetically according to the documentation (https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md)
+# - Add a comment to disable a rule, don't delete it
+# - Every rule must have a short description
+
+# Prefer comma over && in if, guard or while conditions.
+--rules andOperator
+
+# Prefer AnyObject over class in protocol definitions.
+--rules anyObjectProtocol
+
+# Insert blank line before and after MARK: comments.
+--rules blankLinesAroundMark
+
+# Remove trailing blank line at the end of a scope.
+--rules blankLinesAtEndOfScope
+
+# Remove leading blank line at the start of a scope.
+--rules blankLinesAtStartOfScope
+
+# Insert blank line before class, struct, enum, extension, protocol or function declarations.
+--rules blankLinesBetweenScopes
+
+# Wrap braces in accordance with selected style (K&R or Allman).
+--rules braces
+--allman false
+
+# Replace consecutive blank lines with a single blank line.
+--rules consecutiveBlankLines
+
+# Replace consecutive spaces with a single space.
+--rules consecutiveSpaces
+
+# Remove duplicate import statements.
+--rules duplicateImports
+
+# Place else, catch or while keyword in accordance with current style (same or next line).
+--rules elseOnSameLine
+--elseposition same-line
+
+# Remove whitespace inside empty braces.
+--rules emptyBraces
+
+# Converts types used for hosting only static members into enums.
+--rules enumNamespaces
+
+# Configure the placement of an extension's access control keyword.
+--rules extensionAccessControl
+--extensionacl on-declarations
+
+# Use specified source file header template for all files.
+--rules fileHeader
+--header "// Copyright © {year} Bending Spoons S.p.A. All rights reserved."
+
+# Reposition let or var bindings within pattern.
+--rules hoistPatternLet
+--patternlet inline
+
+# Indent code in accordance with the scope level.
+--rules indent
+--indent 2
+--tabwidth 2
+--indentcase false
+--ifdef indent
+--xcodeindentation disabled
+
+# Add @available(*, unavailable) attribute to required init(coder:) when it hasn't been implemented.
+#--rules initCoderUnavailable
+
+# Prefer isEmpty over comparing count against zero.
+--rules isEmpty
+
+# Move leading delimiters to the end of the previous line.
+--rules leadingDelimiters
+
+# Add empty blank line at end of file.
+--rules linebreakAtEndOfFile
+
+# Use specified linebreak character for all linebreaks (CR, LF or CRLF).
+--rules linebreaks
+--linebreaks lf
+
+# Adds a mark comment before top-level types and extensions.
+#--rules markTypes
+
+# Use consistent ordering for member modifiers.
+--rules modifierOrder
+
+# Use consistent grouping for numeric literals. Groups will be separated by _ delimiters to improve readability.
+# For each numeric type you can specify a group size (the number of digits in each group) and a threshold
+# (the minimum number of digits in a number before grouping is applied).
+--rules numberFormatting
+--binarygrouping 4,8
+--decimalgrouping 3,6
+--hexgrouping 2,4
+--octalgrouping 4,8
+--fractiongrouping disabled
+--exponentgrouping enabled
+--hexliteralcase uppercase
+--exponentcase lowercase
+
+# Organizes declarations within class, struct, and enum bodies.
+#--rules organizeDeclarations
+
+# Convert trivial map { $0.foo } closures to keyPath-based syntax.
+--rules preferKeyPath
+
+# Remove redundant backticks around identifiers.
+--rules redundantBackticks
+
+# Remove redundant break in switch case.
+--rules redundantBreak
+
+# Remove redundant access control modifiers.
+--rules redundantExtensionACL
+
+# Prefer private over fileprivate where equivalent.
+--rules redundantFileprivate
+
+# Remove unneeded get clause inside computed properties.
+--rules redundantGet
+
+# Remove explicit init if not required.
+--rules redundantInit
+
+# Remove redundant let/var from ignored variables.
+--rules redundantLet
+
+# Remove redundant let error from catch clause.
+--rules redundantLetError
+
+# Remove redundant nil default value (Optional vars are nil by default).
+--rules redundantNilInit
+
+# Remove redundant @objc annotations.
+--rules redundantObjc
+
+# Remove redundant parentheses.
+--rules redundantParens
+
+# Remove redundant pattern matching parameter syntax.
+--rules redundantPattern
+
+# Remove redundant raw string values for enum cases.
+--rules redundantRawValues
+
+# Remove unneeded return keyword.
+#--rules redundantReturn
+
+# Insert/remove explicit self where applicable.
+--rules redundantSelf
+--self insert
+--selfrequired
+
+# Remove redundant type from variable declarations.
+--rules redundantType
+
+# Remove explicit Void return type.
+--rules redundantVoidReturnType
+
+# Remove semicolons.
+--rules semicolons
+--semicolons inline
+
+# Sort import statements alphabetically.
+--rules sortedImports
+--importgrouping testable-bottom
+
+# Sorts switch cases alphabetically.
+#--rules sortedSwitchCases
+
+# Add or remove space around curly braces.
+--rules spaceAroundBraces
+
+# Add or remove space around square brackets.
+--rules spaceAroundBrackets
+
+# Add space before and/or after comments.
+--rules spaceAroundComments
+
+# Remove space around angle brackets.
+--rules spaceAroundGenerics
+
+# Add or remove space around operators or delimiters.
+--rules spaceAroundOperators
+--operatorfunc spaced
+
+# Add or remove space around parentheses.
+--rules spaceAroundParens
+
+# Add space inside curly braces.
+--rules spaceInsideBraces
+
+# Remove space inside square brackets.
+--rules spaceInsideBrackets
+
+# Add leading and/or trailing space inside comments.
+--rules spaceInsideComments
+
+# Remove space inside angle brackets.
+--rules spaceInsideGenerics
+
+# Remove space inside parentheses.
+--rules spaceInsideParens
+
+# Remove weak modifier from @IBOutlet properties.
+#--rules strongOutlets
+
+# Remove backticks around self in Optional unwrap expressions.
+--rules strongifiedSelf
+
+# Use correct formatting for TODO:, MARK: or FIXME: comments.
+--rules todos
+
+# Use trailing closure syntax where applicable.
+--rules trailingClosures
+--trailingclosures
+
+# Add or remove trailing comma from the last item in a collection literal.
+--rules trailingCommas
+--commas always
+
+# Remove trailing space at end of a line.
+--rules trailingSpace
+--trimwhitespace always
+
+# Prefer shorthand syntax for Arrays, Dictionaries and Optionals.
+--rules typeSugar
+
+# Mark unused function arguments with _.
+--rules unusedArguments
+--stripunusedargs always
+
+# Use Void for type declarations and () for values.
+--rules void
+--empty void
+
+# Wrap lines that exceed the specified maximum width.
+--rules wrap
+--maxwidth 130
+
+# Align wrapped function arguments or collection elements.
+--rules wrapArguments
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--wrapconditions after-first
+--closingparen balanced
+
+# Wrap @attributes onto a separate line, or keep them on the same line.
+#--rules wrapAttributes
+
+# Writes one enum case per line.
+--rules wrapEnumCases
+
+# Wrap the opening brace of multiline statements.
+#--rules wrapMultilineStatementBraces
+
+# Writes one switch case per line.
+#--rules wrapSwitchCases
+
+# Prefer constant values to be on the right-hand-side of expressions.
+--rules yodaConditions
+
+# Optionally ignore conflict markers (e.g. if they clash with a custom operator)
+--conflictmarkers reject
+
+# Support for formatting partial file fragments
+--fragment false
+
+# Some rules depended on the swiftversion and will be disabled automatically if it's not specified or supported
+--swiftversion 5

--- a/solutions/devsprint-riccardo-1/.swiftlint.yml
+++ b/solutions/devsprint-riccardo-1/.swiftlint.yml
@@ -1,0 +1,627 @@
+only_rules:
+  # Prefer using AnyObject over class for class-only protocols
+  # - anyobject_protocol // Already enforced by swiftformat
+
+  # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array
+  # - array_init
+
+  # Attributes should be on their own lines in functions and types, but on the same line as variables and imports
+  # - attributes
+
+  # Test classes must implement balanced setUp and tearDown methods.
+  # - balanced_xctest_lifecycle
+
+  # Prefer the new block based KVO API with keypaths when using Swift 3.2 or later
+  # - block_based_kvo
+
+  # Warn about listing a non-constant (var) variable in a closure's capture list. This captures the variable's value at closure creation time instead of closure call time, which may be unexpected.
+  - capture_variable
+
+  # Delegate protocols should be class-only so they can be weakly referenced
+  - class_delegate_protocol
+
+  # Closing brace with closing parenthesis should not have any whitespaces in the middle
+  - closing_brace
+
+  # Closure bodies should not span too many lines
+  # - closure_body_length
+
+  # Closure end should have the same indentation as the line that started it
+  # - closure_end_indentation // Sometimes the output is weird. See https://github.com/BendingSpoons/splice-iOS-swift/pull/2105/commits/fef69c85801eeaeb372cc6eda5ae5899430af5e0#r574650256
+
+  # Closure parameters should be on the same line as opening brace
+  - closure_parameter_position
+
+  # Closure expressions should have a single space inside each brace
+  - closure_spacing
+
+  # All elements in a collection literal should be vertically aligned
+  - collection_alignment
+
+  # Colons should be next to the identifier when specifying a type and next to the key in dictionary literals
+  - colon
+
+  # There should be no space before and one after any comma
+  - comma
+
+  # Prefer at least one space after slashes for comments
+  - comment_spacing
+
+  # The initializers declared in compiler protocols such as ExpressibleByArrayLiteral shouldn’t be called directly
+  - compiler_protocol_init
+
+  # Getter and setters in computed properties and subscripts should be in a consistent order
+  - computed_accessors_order
+
+  # Conditional statements should always return on the next line
+  # - conditional_returns_on_newline
+
+  # Prefer contains over comparing filter(where:).count to 0
+  - contains_over_filter_count
+
+  # Prefer contains over using filter(where:).isEmpty
+  - contains_over_filter_is_empty
+
+  # Prefer contains over first(where:) != nil and firstIndex(where:) != nil
+  - contains_over_first_not_nil
+
+  # Prefer contains over range(of:) != nil and range(of:) == nil
+  - contains_over_range_nil_comparison
+
+  # if, for, guard, switch, while, and catch statements shouldn’t unnecessarily wrap their conditionals or arguments in parentheses
+  - control_statement
+
+  # Types used for hosting only static members should be implemented as a caseless enum to avoid instantiation
+  - convenience_type
+
+  # Create custom rules by providing a regex string. Optionally specify what syntax kinds to match against, the severity level, and what message to display
+  # - custom_rules
+
+  # Complexity of function bodies should be limited
+  # - cyclomatic_complexity
+
+  # Availability checks or attributes shouldn’t be using older versions that are satisfied by the deployment target
+  - deployment_target
+
+  # When registering for a notification using a block, the opaque observer that is returned should be stored so it can be removed later
+  - discarded_notification_center_observer
+
+  # Prefer assertionFailure() and/or preconditionFailure() over assert(false)
+  - discouraged_assert
+
+  # Discouraged direct initialization of types that can be harmful
+  - discouraged_direct_init
+
+  # Prefer initializers over object literals.
+  - discouraged_object_literal
+
+  # Prefer non-optional booleans over optional booleans.
+  - discouraged_optional_boolean
+
+  # Prefer empty collection over optional collection.
+  - discouraged_optional_collection
+
+  # Enum can’t contain multiple cases with the same name
+  - duplicate_enum_cases
+
+  # Imports should be unique
+  - duplicate_imports
+
+  # Avoid using ‘dynamic’ and ‘@inline(__always)’ together
+  # - dynamic_inline
+
+  # Prefer checking isEmpty over comparing collection to an empty array or dictionary literal
+  - empty_collection_literal
+
+  # Prefer checking isEmpty over comparing count to zero
+  - empty_count
+
+  # Arguments can be omitted when matching enums with associated values if they are not used
+  # - empty_enum_arguments // See issue https://github.com/realm/SwiftLint/issues/3562
+
+  # Prefer () -> over Void ->.
+  - empty_parameters
+
+  # When using trailing closures, empty parentheses should be avoided after the method call
+  - empty_parentheses_with_trailing_closure
+
+  # Prefer checking isEmpty over comparing string to an empty string literal
+  - empty_string
+
+  # Empty XCTest method should be avoided
+  - empty_xctest_method
+
+  # Number of associated values in an enum case should be low
+  # - enum_case_associated_values_count
+
+  # TODOs and FIXMEs should be resolved prior to their expiry date
+  # - expiring_todo
+
+  # All declarations should specify Access Control Level keywords explicitly
+  # - explicit_acl
+
+  # Enums should be explicitly assigned their raw values
+  # - explicit_enum_raw_value
+
+  # Explicitly calling .init() should be avoided
+  - explicit_init
+
+  # Instance variables and functions should be explicitly accessed with ‘self.’
+  - explicit_self
+
+  # Top-level declarations should specify Access Control Level keywords explicitly
+  # - explicit_top_level_acl
+
+  # Properties should have a type interface
+  # - explicit_type_interface
+
+  # Prefer to use extension access modifiers
+  # - extension_access_modifier
+
+  # Fallthrough should be avoided
+  - fallthrough
+
+  # A fatalError call should have a message
+  # - fatal_error_message
+
+  # Header comments should be consistent with project patterns.
+  # The SWIFTLINT_CURRENT_FILENAME placeholder can optionally be used in the required and forbidden patterns.
+  # It will be replaced by the real file name.
+  # - file_header
+
+  # Files should not span too many lines
+  # - file_length
+
+  # File name should match a type or extension declared in the file (if any)
+  # - file_name
+
+  # File name should not contain any whitespace
+  - file_name_no_space
+
+  # Specifies how the types within a file should be ordered
+  # - file_types_order
+
+  # Prefer using .first(where:) over .filter { }.first in collections
+  - first_where
+
+  # Prefer flatMap over map followed by reduce([], +)
+  - flatmap_over_map_reduce
+
+  # where clauses are preferred over a single if inside a for
+  - for_where
+
+  # Force casts should be avoided
+  - force_cast
+
+  # Force tries should be avoided
+  - force_try
+
+  # Force unwrapping should be avoided
+  - force_unwrapping
+
+  # Functions bodies should not span too many lines
+  - function_body_length
+
+  # Prefer to locate parameters with defaults toward the end of the parameter list
+  # - function_default_parameter_at_end
+
+  # Number of function parameters should be low
+  # - function_parameter_count
+
+  # Generic type name should only contain alphanumeric characters, start with an uppercase character and span between 1 and 20 characters in length
+  - generic_type_name
+
+  # Extensions shouldn’t add @IBInspectable properties
+  # - ibinspectable_in_extension
+
+  # Comparing two identical operands is likely a mistake
+  - identical_operands
+
+  # Identifier names should only contain alphanumeric characters and start with a lowercase character or should only contain capital letters.
+  # In an exception to the above, variable names may start with a capital letter when they are declared static and immutable.
+  # Variable names should not be too long or too short
+  - identifier_name
+
+  # Computed read-only properties and subscripts should avoid using the get keyword
+  - implicit_getter
+
+  # Prefer implicit returns in closures, functions and getters
+  # - implicit_return
+
+  # Implicitly unwrapped optionals should be avoided when possible
+  - implicitly_unwrapped_optional
+
+  # Identifiers should use inclusive language that avoids discrimination against groups of people based on race, gender, or socioeconomic status
+  # - inclusive_language
+
+  # Indent code using either one tab or the configured amount of spaces, unindent to match previous indentations. Don’t indent the first line
+  # - indentation_width
+
+  # If defer is at the end of its parent scope, it will be executed right where it is anyway
+  # - inert_defer
+
+  # Prefer using Set.isDisjoint(with:) over Set.intersection(_:).isEmpty
+  - is_disjoint
+
+  # Discouraged explicit usage of the default separator
+  # - joined_default_parameter
+
+  # Tuples shouldn’t have too many members. Create a custom type instead
+  - large_tuple
+
+  # Prefer using .last(where:) over .filter { }.last in collections
+  - last_where
+
+  # Files should not contain leading whitespace
+  - leading_whitespace
+
+  # Struct extension properties and methods are preferred over legacy functions
+  - legacy_cggeometry_functions
+
+  # Struct-scoped constants are preferred over legacy global constants
+  - legacy_constant
+
+  # Swift constructors are preferred over legacy convenience functions
+  - legacy_constructor
+
+  # Prefer using the hash(into:) function instead of overriding hashValue
+  - legacy_hashing
+
+  # Prefer using the isMultiple(of:) function instead of using the remainder operator (%)
+  - legacy_multiple
+
+  # Struct extension properties and methods are preferred over legacy functions
+  - legacy_nsgeometry_functions
+
+  # Prefer using type.random(in:) over legacy functions
+  - legacy_random
+
+  # Let and var should be separated from other statements by a blank line
+  # - let_var_whitespace
+
+  # Lines should not span too many characters
+  - line_length
+
+  # Array and dictionary literal end should have the same indentation as the line that started it
+  - literal_expression_end_indentation
+
+  # Ensure definitions have a lower access control level than their enclosing parent
+  - lower_acl_than_parent
+
+  # MARK comment should be in valid format. e.g. ‘// MARK: …’ or ‘// MARK: - …’
+  - mark
+
+  # Public declarations should be documented
+  - missing_docs
+
+  # Modifier order should be consistent
+  # - modifier_order // Already enforced by swiftformat
+
+  # Arguments should be either on the same line, or one per line
+  - multiline_arguments
+
+  # Multiline arguments should have their surrounding brackets in a new line
+  # - multiline_arguments_brackets // Sometimes the output is weird. See https://github.com/BendingSpoons/splice-iOS-swift/pull/2105#issuecomment-781186973
+
+  # Chained function calls should be either on the same line, or one per line
+  - multiline_function_chains
+
+  # Multiline literals should have their surrounding brackets in a new line
+  - multiline_literal_brackets
+
+  # Functions and methods parameters should be either on the same line, or one per line
+  - multiline_parameters
+
+  # Multiline parameters should have their surrounding brackets in a new line
+  - multiline_parameters_brackets
+
+  # Trailing closure syntax should not be used when passing more than one closure argument
+  - multiple_closures_with_trailing_closure
+
+  # Types should be nested at most 1 level deep, and functions should be nested at most 2 levels deep
+  # - nesting
+
+  # Prefer Nimble operator overloads over free matcher functions
+  # - nimble_operator
+
+  # Prefer not to use extension access modifiers
+  # - no_extension_access_modifier
+
+  # Fallthroughs can only be used if the case contains at least one other statement
+  # - no_fallthrough_only
+
+  # Extensions shouldn’t be used to group code within the same source file
+  # - no_grouping_extension
+
+  # Don’t add a space between the method name and the parentheses
+  - no_space_in_method_call
+
+  # An object should only remove itself as an observer in deinit
+  # - notification_center_detachment
+
+  # Static strings should be used as key/comment in NSLocalizedString in order for genstrings to work
+  # - nslocalizedstring_key
+
+  # Calls to NSLocalizedString should specify the bundle which contains the strings file
+  # - nslocalizedstring_require_bundle
+
+  # NSObject subclasses should implement isEqual instead of ==
+  # - nsobject_prefer_isequal
+
+  # Underscores should be used as thousand separator in large decimal numbers
+  # - number_separator
+
+  # Prefer object literals over image and color inits
+  - object_literal
+
+  # Opening braces should be preceded by a single space and on the same line as the declaration
+  # - opening_brace // Sometimes the output is weird. See https://github.com/BendingSpoons/splice-iOS-swift/pull/2105#issuecomment-780445280
+
+  # Operators should be surrounded by a single whitespace when they are being used
+  - operator_usage_whitespace
+
+  # Operators should be surrounded by a single whitespace when defining them
+  - operator_whitespace
+
+  # Matching an enum case against an optional enum without ‘?’ is supported on Swift 5.1 and above
+  - optional_enum_case_matching
+
+  # A doc comment should be attached to a declaration
+  - orphaned_doc_comment
+
+  # Some overridden methods should always call super
+  - overridden_super_call
+
+  # Extensions shouldn’t override declarations
+  # - override_in_extension
+
+  # Combine multiple pattern matching bindings by moving keywords out of tuples
+  # - pattern_matching_keywords
+
+  # Prefer Nimble matchers over XCTAssert functions
+  # - prefer_nimble
+
+  # Prefer Self over type(of: self) when accessing properties or calling methods
+  - prefer_self_type_over_type_of_self
+
+  # Prefer .zero over explicit init with zero parameters (e.g. CGPoint(x: 0, y: 0))
+  - prefer_zero_over_explicit_init
+
+  # Top-level constants should be prefixed by k
+  # - prefixed_toplevel_constant
+
+  # IBActions should be private
+  # - private_action
+
+  # IBOutlets should be private to avoid leaking UIKit to higher layers
+  # - private_outlet
+
+  # Prefer private over fileprivate declarations
+  # - private_over_fileprivate
+
+  # Combine Subject should be private
+  # - private_subject
+
+  # Unit tests marked private are silently skipped
+  # - private_unit_test
+
+  # Creating views using Interface Builder should be avoided
+  # - prohibited_interface_builder
+
+  # Some methods should not call super
+  - prohibited_super_call
+
+  # When declaring properties in protocols, the order of accessors should be get set
+  - protocol_property_accessors_order
+
+  # Discouraged call inside ‘describe’ and/or ‘context’ block
+  # - quick_discouraged_call
+
+  # Discouraged focused test. Other tests won’t run while this one is focused
+  # - quick_discouraged_focused_test
+
+  # Discouraged pending test. This test won’t run while it’s marked as pending
+  # - quick_discouraged_pending_test
+
+  # Camel cased cases of Codable String enums should have raw value
+  # - raw_value_for_camel_cased_codable_enum
+
+  # Prefer using .allSatisfy() or .contains() over reduce(true) or reduce(false)
+  - reduce_boolean
+
+  # Prefer reduce(into:_:) over reduce(_:_:) for copy-on-write types
+  - reduce_into
+
+  # Prefer _ = foo() over let _ = foo() when discarding a result from a function
+  - redundant_discardable_let
+
+  # nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant
+  - redundant_nil_coalescing
+
+  # Objective-C attribute (@objc) is redundant in declaration
+  - redundant_objc_attribute
+
+  # Initializing an optional variable with nil is redundant
+  - redundant_optional_initialization
+
+  # Property setter access level shouldn’t be explicit if it’s the same as the variable access level
+  # - redundant_set_access_control
+
+  # String enum values can be omitted when they are equal to the enumcase name
+  - redundant_string_enum_value
+
+  # Variables should not have redundant type annotation
+  - redundant_type_annotation
+
+  # Returning Void in a function declaration is redundant
+  - redundant_void_return
+
+  # Classes should have an explicit deinit method
+  # - required_deinit
+
+  # Enums conforming to a specified protocol must implement a specific case(s)
+  # - required_enum_case
+
+  # Return arrow and return type should be separated by a single space or on a separate line
+  - return_arrow_whitespace
+
+  # Prefer shorthand operators (+=, -=, *=, /=) over doing the operation and assigning
+  - shorthand_operator
+
+  # Test files should contain a single QuickSpec or XCTestCase class
+  - single_test_class
+
+  # Prefer using min() or max() over sorted().first or sorted().last
+  - sorted_first_last
+
+  # Imports should be sorted.
+  # - sorted_imports // Already enforced by swiftformat
+
+  # Else and catch should be on the same line, one space after the previous declaration
+  - statement_position
+
+  # Operators should be declared as static functions, not free functions
+  - static_operator
+
+  # fileprivate should be avoided
+  # - strict_fileprivate
+
+  # @IBOutlets shouldn’t be declared as weak
+  # - strong_iboutlet
+
+  # SwiftLint ‘disable’ commands are superfluous when the disabled rule would not have triggered a violation
+  # in the disabled region. Use “ - ” if you wish to document a command
+  - superfluous_disable_command
+
+  # Case statements should vertically align with their enclosing switch statement, or indented if configured otherwise
+  - switch_case_alignment
+
+  # Cases inside a switch should always be on a newline
+  # - switch_case_on_newline
+
+  # Shorthand syntactic sugar should be used, i.e. [Int] instead of Array
+  - syntactic_sugar
+
+  # Test cases should only contain private non-test members
+  # - test_case_accessibility
+
+  # TODOs and FIXMEs should be resolved
+  # - todo
+
+  # Prefer someBool.toggle() over someBool = !someBool
+  - toggle_bool
+
+  # Trailing closure syntax should be used whenever possible
+  # - trailing_closure
+
+  # Trailing commas in arrays and dictionaries should be avoided/enforced
+  # - trailing_comma
+
+  # Files should have a single trailing newline
+  - trailing_newline
+
+  # Lines should not have trailing semicolons
+  - trailing_semicolon
+
+  # Lines should not have trailing whitespace
+  - trailing_whitespace
+
+  # Type bodies should not span too many lines
+  # - type_body_length
+
+  # Specifies the order of subtypes, properties, methods & more within a type
+  # - type_contents_order
+
+  # Type name should only contain alphanumeric characters, start with an uppercase character and span between 3 and 40 characters in length
+  - type_name
+
+  # Unimplemented functions should be marked as unavailable
+  # - unavailable_function
+
+  # Avoid using unneeded break statements
+  - unneeded_break_in_switch
+
+  # Parentheses are not needed when declaring closure arguments
+  - unneeded_parentheses_in_closure_argument
+
+  # Prefer capturing references as weak to avoid potential crashes
+  # - unowned_variable_capture
+
+  # Catch statements should not declare error variables without type casting
+  # - untyped_error_in_catch
+
+  # Unused reference in a capture list should be removed
+  - unused_capture_list
+
+  # Unused parameter in a closure should be replaced with _
+  - unused_closure_parameter
+
+  # Unused control flow label should be removed
+  - unused_control_flow_label
+
+  # Declarations should be referenced at least once within all files linted
+  - unused_declaration
+
+  # When the index or the item is not used, .enumerated() can be removed
+  - unused_enumerated
+
+  # All imported modules should be required to make the file compile
+  - unused_import
+
+  # Prefer != nil over let _ =
+  - unused_optional_binding
+
+  # Setter value is not used
+  - unused_setter_value
+
+  # @IBInspectable should be applied to variables only, have its type explicit and be of a supported type
+  # - valid_ibinspectable
+
+  # Function parameters should be aligned vertically if they’re in multiple lines in a declaration.
+  # - vertical_parameter_alignment
+
+  # Function parameters should be aligned vertically if they’re in multiple lines in a method call
+  # - vertical_parameter_alignment_on_call
+
+  # Limit vertical whitespace to a single empty line
+  - vertical_whitespace
+
+  # Include a single empty line between switch cases
+  # - vertical_whitespace_between_cases
+
+  # Don’t include vertical whitespace (empty line) before closing braces
+  - vertical_whitespace_closing_braces
+
+  # Don’t include vertical whitespace (empty line) after opening braces
+  - vertical_whitespace_opening_braces
+
+  # Prefer -> Void over -> ()
+  - void_return
+
+  # Delegates should be weak to avoid reference cycles
+  - weak_delegate
+
+  # Prefer specific XCTest matchers over XCTAssertEqual and XCTAssertNotEqual
+  - xct_specific_matcher
+
+  # An XCTFail call should include a description of the assertion
+  - xctfail_message
+
+  # The variable should be placed on the left, the constant on the right of a comparison operator.
+  - yoda_condition
+
+line_length: 130
+
+identifier_name:
+  min_length: 1
+  max_length: 60
+
+type_name:
+  min_length: 1
+  max_length: 60
+
+generic_type_name:
+  max_length: 35
+
+function_body_length:
+  warning: 100

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge.xcodeproj/project.pbxproj
@@ -211,6 +211,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 980C0C3E2705078100F8100A /* Build configuration list for PBXNativeTarget "OnboardingChallenge" */;
 			buildPhases = (
+				46B812DB2768EFC600A4867B /* Formatting */,
+				46B812DA2768EF8800A4867B /* Linting */,
 				980C0C262705077B00F8100A /* Sources */,
 				980C0C272705077B00F8100A /* Frameworks */,
 				980C0C282705077B00F8100A /* Resources */,
@@ -298,6 +300,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		46B812DA2768EF8800A4867B /* Linting */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Linting;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --fix\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		46B812DB2768EFC600A4867B /* Formatting */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Formatting;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		980C0C262705077B00F8100A /* Sources */ = {

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/AppDelegate.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/AppDelegate.swift
@@ -1,25 +1,20 @@
-//
-//  AppDelegate.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 29/09/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    return true
+  }
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+  // MARK: UISceneSession Lifecycle
 
-        return true
-    }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
+  func application(
+    _: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options _: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
 }
-

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/SceneDelegate.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/SceneDelegate.swift
@@ -1,24 +1,16 @@
-//
-//  SceneDelegate.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 29/09/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
 
-    var window: UIWindow?
+  func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
+    guard let windowScene = (scene as? UIWindowScene) else { return }
 
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-
-        self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.window?.rootViewController = UINavigationController(rootViewController: ListViewController())
-        self.window?.windowScene = windowScene
-        self.window?.makeKeyAndVisible()
-    }
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    self.window?.rootViewController = UINavigationController(rootViewController: ListViewController())
+    self.window?.windowScene = windowScene
+    self.window?.makeKeyAndVisible()
+  }
 }
-

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/String+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/String+Extensions.swift
@@ -1,16 +1,9 @@
-//
-//  String+Extensions.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import Foundation
 
 extension String {
-
-    static func repositoryInfo(repositoriesCount: Int, bifurcationsCount: Int) -> String {
-
-        return "\(repositoriesCount) stars   \(bifurcationsCount) bifurcations"
-    }
+  static func repositoryInfo(repositoriesCount: Int, bifurcationsCount: Int) -> String {
+    return "\(repositoriesCount) stars   \(bifurcationsCount) bifurcations"
+  }
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIColor+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIColor+Extensions.swift
@@ -1,19 +1,14 @@
-//
-//  UIColor+Extensions.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 extension UIColor {
-
-    convenience init(red: Int, green: Int, blue: Int) {
-        
-        self.init(red: CGFloat(red)/255.0,
-                  green: CGFloat(green)/255.0,
-                  blue: CGFloat(blue)/255.0,
-                  alpha: 1)
-    }
+  convenience init(red: Int, green: Int, blue: Int) {
+    self.init(
+      red: CGFloat(red) / 255.0,
+      green: CGFloat(green) / 255.0,
+      blue: CGFloat(blue) / 255.0,
+      alpha: 1
+    )
+  }
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UITableViewCell+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UITableViewCell+Extensions.swift
@@ -1,19 +1,13 @@
-//
-//  UITableViewCell+Extensions.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 extension UITableViewCell {
-
-    class func classIdentifier() -> String {
-        guard let className = String(describing: self).components(separatedBy: ".").last else {
-            return ""
-        }
-
-        return className
+  class func classIdentifier() -> String {
+    guard let className = String(describing: self).components(separatedBy: ".").last else {
+      return ""
     }
+
+    return className
+  }
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIViewController+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIViewController+Extensions.swift
@@ -1,19 +1,12 @@
-//
-//  UIViewController+Extensions.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 extension UIViewController {
+  func insideNavigationController() -> UINavigationController {
+    let navigationController = UINavigationController(rootViewController: self)
+    navigationController.modalPresentationStyle = .formSheet
 
-    func insideNavigationController() -> UINavigationController {
-
-        let navigationController = UINavigationController(rootViewController: self)
-        navigationController.modalPresentationStyle = .formSheet
-
-        return navigationController
-    }
+    return navigationController
+  }
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
@@ -1,46 +1,38 @@
-//
-//  SwiftUIPreView.swift
-//  OnboardingChallenge
-//
-//  Created by Riccardo Cipolleschi on 10/12/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import Foundation
 
 #if DEBUG
-import SwiftUI
+  import SwiftUI
 
-/// Generic structure that implement the boilerplate to make a UIView representable in SwiftUI
-/// This struct is meant to be used in SwiftUI previews, where we are interested in quickly checking
-/// what we are implementing. It shouldn't be used when you need a UIKit component work with the
-/// SwiftUI parts of the production app.
-///
-/// To use it, copy and paste the following snippet in the UIKit View and replace the name of the preview
-/// and the commented code.
-///
-/// ```swift
-/// #if DEBUG
-/// import SwiftUI
-///
-/// struct <#YourView#>_Preview: PreviewProvider {
-///     static var previews: some View {
-///         return SwiftUIPreView { context in
-///             // code to initialize and configure your view
-///         }
-///     }
-/// }
-/// #endif
-/// ```
-struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
-    
+  /// Generic structure that implement the boilerplate to make a UIView representable in SwiftUI
+  /// This struct is meant to be used in SwiftUI previews, where we are interested in quickly checking
+  /// what we are implementing. It shouldn't be used when you need a UIKit component work with the
+  /// SwiftUI parts of the production app.
+  ///
+  /// To use it, copy and paste the following snippet in the UIKit View and replace the name of the preview
+  /// and the commented code.
+  ///
+  /// ```swift
+  /// #if DEBUG
+  /// import SwiftUI
+  ///
+  /// struct <#YourView#>_Preview: PreviewProvider {
+  ///     static var previews: some View {
+  ///         return SwiftUIPreView { context in
+  ///             // code to initialize and configure your view
+  ///         }
+  ///     }
+  /// }
+  /// #endif
+  /// ```
+  struct SwiftUIPreView<V>: UIViewRepresentable where V: UIView {
     let viewFactory: (Context) -> V
-    
+
     func makeUIView(context: Context) -> V {
-        return viewFactory(context)
+      return self.viewFactory(context)
     }
-    
-    func updateUIView(_ uiView: V, context: Context) {
-        
-    }
-}
+
+    func updateUIView(_: V, context _: Context) {}
+  }
 #endif

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Detail/DetailViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Detail/DetailViewController.swift
@@ -1,12 +1,5 @@
-//
-//  DetailViewController.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 03/11/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
-class DetailViewController: UIViewController {
-    
-}
+class DetailViewController: UIViewController {}

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
@@ -1,102 +1,85 @@
-//
-//  ListView.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 30/09/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 final class ListView: UIView {
+  private let listViewCellIdentifier = "ListViewCellIdentifier"
 
-    private let listViewCellIdentifier = "ListViewCellIdentifier"
+  private var listItems: [String] = []
 
-    private var listItems: [String] = []
+  private lazy var tableView: UITableView = {
+    let tableView = UITableView(frame: .zero)
+    tableView.translatesAutoresizingMaskIntoConstraints = false
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.listViewCellIdentifier)
+    tableView.dataSource = self
+    return tableView
+  }()
 
-    private lazy var tableView: UITableView = {
+  init() {
+    super.init(frame: .zero)
 
-        let tableView = UITableView(frame: .zero)
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.listViewCellIdentifier)
-        tableView.dataSource = self
-        return tableView
-    }()
+    self.customizeInterface()
+  }
 
-    init() {
-
-        super.init(frame: .zero)
-
-        self.customizeInterface()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
-private extension ListView {
-
-    func customizeInterface() {
-
-        self.backgroundColor = .white
-
-        self.configureSubviews()
-        self.configureSubviewsConstraints()
-    }
-
-    func configureSubviews() {
-
-        self.addSubview(self.tableView)
-    }
-
-    func configureSubviewsConstraints() {
-
-        NSLayoutConstraint.activate([
-
-            self.tableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.tableView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-        ])
-    }
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 }
 
 extension ListView {
+  private func customizeInterface() {
+    self.backgroundColor = .white
 
-    func updateView(with configuration: ListViewConfiguration) {
+    self.configureSubviews()
+    self.configureSubviewsConstraints()
+  }
 
-        self.listItems = configuration.listItems
-        self.tableView.reloadData()
-    }
+  private func configureSubviews() {
+    self.addSubview(self.tableView)
+  }
+
+  private func configureSubviewsConstraints() {
+    NSLayoutConstraint.activate([
+      self.tableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.tableView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+  }
+}
+
+extension ListView {
+  func updateView(with configuration: ListViewConfiguration) {
+    self.listItems = configuration.listItems
+    self.tableView.reloadData()
+  }
 }
 
 extension ListView: UITableViewDataSource {
+  public func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+    return self.listItems.count
+  }
 
-    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
-        return self.listItems.count
-    }
-
-    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-
-        let cell = tableView.dequeueReusableCell(withIdentifier: self.listViewCellIdentifier)!
-        cell.textLabel?.text = self.listItems[indexPath.row]
-        return cell
-    }
+  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: self.listViewCellIdentifier)!
+    cell.textLabel?.text = self.listItems[indexPath.row]
+    return cell
+  }
 }
 
 #if DEBUG
-import SwiftUI
-
-struct ListView_Preview: PreviewProvider {
+  import SwiftUI
+  // swiftlint:disable type_name
+  struct ListView_Preview: PreviewProvider {
     static var previews: some View {
-        return SwiftUIPreView { context in
-            let lv = ListView()
-            lv.updateView(with: .init(listItems: [
-                "first", "second", "third", "fourth"
-            ]))
-            return lv
-        }
+      return SwiftUIPreView { _ in
+        let lv = ListView()
+        lv.updateView(with: .init(listItems: [
+          "first", "second", "third", "fourth",
+        ]))
+        return lv
+      }
     }
-}
+  }
+  // swiftlint:enable type_name
 #endif

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewConfiguration.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewConfiguration.swift
@@ -1,13 +1,7 @@
-//
-//  ListViewConfiguration.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import Foundation
 
 struct ListViewConfiguration {
-
-    let listItems: [String]
+  let listItems: [String]
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewController.swift
@@ -1,48 +1,36 @@
-//
-//  ViewController.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 29/09/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
 final class ListViewController: UIViewController {
+  private lazy var listView: ListView = {
+    return ListView()
+  }()
 
-    private lazy var listView: ListView = {
+  private let service = Service()
 
-        return ListView()
-    }()
+  init() {
+    super.init(nibName: nil, bundle: nil)
+  }
 
-    private let service = Service()
- 
-    init() {
-        super.init(nibName: nil, bundle: nil)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
+  override func loadView() {
+    self.view = self.listView
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.fetchList()
+  }
+
+  private func fetchList() {
+    self.service.fetchList { items in
+      let configuration = ListViewConfiguration(listItems: items)
+
+      self.listView.updateView(with: configuration)
     }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func loadView() {
-        self.view = self.listView
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.fetchList()
-    }
-
-    private func fetchList() {
-
-        self.service.fetchList { items in
-
-            let configuration = ListViewConfiguration(listItems: items)
-
-            self.listView.updateView(with: configuration)
-        }
-    }
+  }
 }
-
-

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Settings/SettingsViewController.swift
@@ -1,12 +1,5 @@
-//
-//  SettingsViewController.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 03/11/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import UIKit
 
-class SettingsViewController {
-    
-}
+class SettingsViewController {}

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Service/Service.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Service/Service.swift
@@ -1,21 +1,13 @@
-//
-//  Service.swift
-//  OnboardingChallenge
-//
-//  Created by Rodrigo Borges on 30/09/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import Foundation
 
 protocol ServiceProtocol {
-
-    func fetchList(_ completion: ([String]) -> Void)
+  func fetchList(_ completion: ([String]) -> Void)
 }
 
 struct Service: ServiceProtocol {
-
-    func fetchList(_ completion: ([String]) -> Void) {
-
-        completion(["Item 1", "Item 2", "Item 3"])
-    }
+  func fetchList(_ completion: ([String]) -> Void) {
+    completion(["Item 1", "Item 2", "Item 3"])
+  }
 }

--- a/solutions/devsprint-riccardo-1/OnboardingChallengeTests/OnboardingChallengeTests.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallengeTests/OnboardingChallengeTests.swift
@@ -1,32 +1,25 @@
-//
-//  OnboardingChallengeTests.swift
-//  OnboardingChallengeTests
-//
-//  Created by Rodrigo Borges on 06/10/21.
-//
+// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
 
 import XCTest
 
 class OnboardingChallengeTests: XCTestCase {
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+
+  func testExample() throws {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+  }
+
+  func testPerformanceExample() throws {
+    // This is an example of a performance test case.
+    measure {
+      // Put the code you want to measure the time of here.
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+  }
 }


### PR DESCRIPTION
This PR configures the Challenge-Onboarding to work with [SwiftLint](https://github.com/realm/SwiftLint) and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat), which are the _de facto_ standard to keep the codebase aligned in swift.

The PR introduces a `bin` folder with a script that can be executed to install the two tools.
Then, it configures the `.xcodeproj` to work with the tools. 

Finally, it imports a set of rules for each tool.

Some files have been updated automatically after the tools have been configured.