### PR TITLE
[FIX] Make sure to use the right copyright in all the files

### DIFF
--- a/solutions/devsprint-riccardo-1/.swiftformat
+++ b/solutions/devsprint-riccardo-1/.swiftformat
@@ -50,7 +50,7 @@
 
 # Use specified source file header template for all files.
 --rules fileHeader
---header "// Copyright © {year} Bending Spoons S.p.A. All rights reserved."
+--header "// Copyright © {year} DevPass. All rights reserved."
 
 # Reposition let or var bindings within pattern.
 --rules hoistPatternLet

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/AppDelegate.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/AppDelegate.swift
@@ -1,12 +1,15 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+  // swiftlint:disable discouraged_optional_collection
   func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     return true
   }
+
+  // swiftlint:enable discouraged_optional_collection
 
   // MARK: UISceneSession Lifecycle
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/SceneDelegate.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/AppDelegate/SceneDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/String+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/String+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import Foundation
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIColor+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIColor+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UITableViewCell+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UITableViewCell+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIViewController+Extensions.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Extensions/UIViewController+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Helpers/SwiftUIPreView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import Foundation
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Detail/DetailViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Detail/DetailViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 
@@ -63,6 +63,7 @@ extension ListView: UITableViewDataSource {
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: self.listViewCellIdentifier)!
     cell.textLabel?.text = self.listItems[indexPath.row]
+
     return cell
   }
 }
@@ -73,11 +74,9 @@ extension ListView: UITableViewDataSource {
   struct ListView_Preview: PreviewProvider {
     static var previews: some View {
       return SwiftUIPreView { _ in
-        let lv = ListView()
-        lv.updateView(with: .init(listItems: [
-          "first", "second", "third", "fourth",
-        ]))
-        return lv
+        let listView = ListView()
+        listView.updateView(with: .init(listItems: ["A", "B"]))
+        return listView
       }
     }
   }

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewConfiguration.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import Foundation
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/List/ListViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Settings/SettingsViewController.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Screens/Settings/SettingsViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import UIKit
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallenge/Service/Service.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallenge/Service/Service.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import Foundation
 

--- a/solutions/devsprint-riccardo-1/OnboardingChallengeTests/OnboardingChallengeTests.swift
+++ b/solutions/devsprint-riccardo-1/OnboardingChallengeTests/OnboardingChallengeTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Bending Spoons S.p.A. All rights reserved.
+// Copyright © 2021 DevPass. All rights reserved.
 
 import XCTest
 


### PR DESCRIPTION
When introducing the SwiftFormat rules, I forgot to update the header rule, which updates the copyright information in the various Swift files. This PR fixes that error.